### PR TITLE
Suite timeout option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "parallel-test-runner",
+  "name": "parallel-test",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -19,6 +19,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
       "integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A=="
+    },
+    "commander": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.1.tgz",
+      "integrity": "sha512-UNgvDd+csKdc9GD4zjtkHKQbT8Aspt2jCBqNSPp53vAS0L1tS9sXB2TCEOPHJ7kt9bN/niWkYj8T3RQSoMXdSQ=="
     },
     "extract-stack": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@types/node": "^10.12.21",
     "clean-stack": "^2.0.0",
+    "commander": "^3.0.1",
     "extract-stack": "^1.0.0",
     "tiny-glob": "^0.2.6"
   },

--- a/src/bin/test-all.ts
+++ b/src/bin/test-all.ts
@@ -1,10 +1,17 @@
 #!/usr/bin/env node
 
+import * as program from 'commander'
 import glob = require('tiny-glob')
 import debugLog from '../debugLog'
 import { resolve as resolvePath } from 'path'
 
-const paths = process.argv.slice(2)
+program
+.option('--maximumDurationSeconds <maximumDurationSeconds>', 'The maximum amount of time that tests in the suite are allowed to run. Defaults to `3600`')
+.option('--path <path>', 'The path to the test file(s) to run. Can be a glob pattern to run many at once. Can be repeated', (newPath, existingPaths) => [...existingPaths, newPath], [])
+
+program.parse(process.argv)
+
+const paths: Array<string> = program.path
 const startTime = Date.now()
 
 if (paths.length === 0) {
@@ -24,5 +31,11 @@ Promise.all(paths.map(path => glob(path)))
       require(resolvePath(process.cwd(), match))
       debugLog(`(${Date.now() - startTime} ms) loaded ${match}`)
     })
+  })
+
+  const setTestSuiteOptions = require('../index').setTestSuiteOptions  // import late so that we don't trigger test runs by loading the module and causing its `setImmediate` to run and start the tests
+
+  setTestSuiteOptions({
+    ...(program.maximumDurationSeconds && { maximumDurationSeconds: program.maximumDurationSeconds })
   })
 })

--- a/src/bin/test-all.ts
+++ b/src/bin/test-all.ts
@@ -7,7 +7,7 @@ import { resolve as resolvePath } from 'path'
 
 program
 .option('--maximumDurationSeconds <maximumDurationSeconds>', 'The maximum amount of time that tests in the suite are allowed to run. Defaults to `3600`')
-.option('--path <path>', 'The path to the test file(s) to run. Can be a glob pattern to run many at once. Can be repeated', (newPath, existingPaths) => [...existingPaths, newPath], [])
+.option('--path <path>', 'The path to the test file(s) to run. Can be a glob pattern to run many at once. Can be repeated, e.g., --path path1 --path path2', (newPath, existingPaths) => [...existingPaths, newPath], [])
 
 program.parse(process.argv)
 

--- a/src/bin/test-all.ts
+++ b/src/bin/test-all.ts
@@ -33,6 +33,11 @@ Promise.all(paths.map(path => glob(path)))
     })
   })
 
+  /**
+   * We load ../index here, instead of at the top of the file, because it must be loaded in the same synchronous chunk of code as test registration (caused by the `require` just above here).
+   * If we were to load `index` asynchronously **before** registering tests, the `setImmediate` in `index` would run the currently-registered tests (none of them) before any could be registered. The test process would exit without running any tests.
+   * If we were to load `index` asynchronously **after** registering tests, we wouldn't be able to set options, because the test run would have started, and options aren't allowed to be set once the test run has begun.
+   */
   const setTestSuiteOptions = require('../index').setTestSuiteOptions  // import late so that we don't trigger test runs by loading the module and causing its `setImmediate` to run and start the tests
 
   setTestSuiteOptions({

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ setImmediate(async () => {
     process.exitCode = errorCount > 0 ? 1 : 0
 
     if (testsTimedOut) {
+        // At this point, all tests that fit into the timeout are done running and all results have been reported. We need to forcefully end the process so that remaining tests that are taking too long to run end, and don't keep the process alive.
         debugLog(`Sending kill signal SIGINT to self (process ID ${process.pid}) because tests timed out. There are ${process.listenerCount(`SIGINT`)} current listeners for this signal.`)
         process.kill(process.pid, `SIGINT`)  // exit the process, but allow handlers to catch the `SIGINT` and clean up as necessary. This is a gentler alternative to `process.exit()`.
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,8 @@ setImmediate(async () => {
     debugLog(`(${Date.now() - startTime} ms) done running tests`)
 
     process.exitCode = errorCount > 0 ? 1 : 0
+
+    debugLog(`Sending kill signal SIGINT to self (process ID ${process.pid}). There are ${process.listenerCount(`SIGINT`)} current listeners for this signal.`)
     process.kill(process.pid, `SIGINT`)  // exit the process, but allow handlers to catch the `SIGINT` and clean up as necessary. This is a gentler alternative to `process.exit()`.
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ async function runTests(options: TestSuiteOptions): Promise<void> {
     writeOutput(`# tests ${tests.length}`)
     writeOutput(`# pass ${successCount}`)
     writeOutput(`# fail ${errorCount}`)
-    writeOutput(`# skipped ${tests.length - successCount - errorCount}`)
+    writeOutput(`# unfinished ${tests.length - successCount - errorCount}`)
 }
 
 function cleanStack({ stack }: { stack: string }): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,16 +4,35 @@ import * as getStackOnly from 'extract-stack'
 import * as util from 'util'
 
 const tests: Array<Test> = []
+let successCount = 0
 let errorCount = 0
 let testsRunning = false
 const writeOutput = (line: string) => console.log(line)
+let testSuiteOptions: TestSuiteOptions = {
+    maximumDurationSeconds: 3600,
+}
+let testSuiteOptionsSet = false
 
 interface Test {
     description: string,
     testFunction: () => Promise<void> | void,
 }
 
+interface TestSuiteOptions {
+    /**
+     * The maximum amount of time that tests in the suite are allowed to run. Defaults to `3600`.
+     *
+     * If, at the end of this time, tests are still running
+     *      If there were any failures, exit with a failure
+     *      If there were no failures, exit with a success
+     */
+    maximumDurationSeconds: number,
+}
+
 export default test
+export {
+    setTestSuiteOptions
+}
 
 function test(description: Test['description'], testFunction: Test['testFunction']): void {
     if (testsRunning) {
@@ -35,20 +54,40 @@ function test(description: Test['description'], testFunction: Test['testFunction
     tests.push(test)
 }
 
+function setTestSuiteOptions(newOptions: Partial<TestSuiteOptions>): void {
+    if (testsRunning) {
+        throw new Error(`Cannot set test suite options once tests are already running`)
+    }
+
+    if (testSuiteOptionsSet) {
+        throw new Error(`Can only set test suite options once`)
+    }
+
+    testSuiteOptionsSet = true
+
+    testSuiteOptions = {
+        ...testSuiteOptions,
+        ...newOptions,
+    }
+}
+
 // Run tests after synchronous test definitions happen. This means that tests MUST be defined synchronously.
 setImmediate(async () => {
     const startTime = Date.now()
     debugLog('running tests')
 
     testsRunning = true
-    await runTests()
+    await runTests(testSuiteOptions)
 
     debugLog(`(${Date.now() - startTime} ms) done running tests`)
 
     process.exitCode = errorCount > 0 ? 1 : 0
+    process.kill(process.pid, `SIGINT`)  // exit the process, but allow handlers to catch the `SIGINT` and clean up as necessary. This is a gentler alternative to `process.exit()`.
 })
 
-async function runTests(): Promise<void> {
+async function runTests(options: TestSuiteOptions): Promise<void> {
+    debugLog(`running test suite with options ${JSON.stringify(options)}`)
+
     writeOutput('TAP version 13')
     writeOutput(`1..${tests.length}`)
 
@@ -59,6 +98,7 @@ async function runTests(): Promise<void> {
         try {
             await test.testFunction()
             writeOutput(`ok ${test.description}`)
+            successCount += 1
         } catch(error) {
             errorCount += 1
 
@@ -74,11 +114,23 @@ async function runTests(): Promise<void> {
         }
     })
 
-    await Promise.all(pendingTests)
+    const pendingSuiteTimeout = new Promise((resolve, reject) => {
+        setTimeout(() => {
+            writeOutput(`# reached ${options.maximumDurationSeconds} seconds, the configured maximumDurationSeconds, timing out`)
+            resolve()
+        }, options.maximumDurationSeconds * 1e3)
+        .unref()  // make sure this doesn't prevent tests from exiting if it's the only pending operation
+    })
+
+    await Promise.race([
+        Promise.all(pendingTests),
+        pendingSuiteTimeout,
+    ])
 
     writeOutput(`# tests ${tests.length}`)
-    writeOutput(`# pass ${tests.length - errorCount}`)
+    writeOutput(`# pass ${successCount}`)
     writeOutput(`# fail ${errorCount}`)
+    writeOutput(`# skipped ${tests.length - successCount - errorCount}`)
 }
 
 function cleanStack({ stack }: { stack: string }): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const writeOutput = (line: string) => console.log(line)
 let testSuiteOptions: TestSuiteOptions = {
     maximumDurationSeconds: 3600,
 }
-let testSuiteOptionsSet = false
+let testSuiteOptionsHaveBeenSet = false
 
 interface Test {
     description: string,
@@ -60,11 +60,11 @@ function setTestSuiteOptions(newOptions: Partial<TestSuiteOptions>): void {
         throw new Error(`Cannot set test suite options once tests are already running`)
     }
 
-    if (testSuiteOptionsSet) {
+    if (testSuiteOptionsHaveBeenSet) {
         throw new Error(`Can only set test suite options once`)
     }
 
-    testSuiteOptionsSet = true
+    testSuiteOptionsHaveBeenSet = true
 
     testSuiteOptions = {
         ...testSuiteOptions,

--- a/src/test/multipleTestSuiteOptionSets.ts
+++ b/src/test/multipleTestSuiteOptionSets.ts
@@ -1,3 +1,7 @@
+/**
+ * This file can be used to test `setTestSuiteOptions` manually, because these things are difficult to write automated tests for. You should see an error thrown by the second `setTestSuiteOptions` call.
+ */
+
 import { setTestSuiteOptions } from '../index'
 
 setTestSuiteOptions({})

--- a/src/test/multipleTestSuiteOptionSets.ts
+++ b/src/test/multipleTestSuiteOptionSets.ts
@@ -1,0 +1,4 @@
+import { setTestSuiteOptions } from '../index'
+
+setTestSuiteOptions({})
+setTestSuiteOptions({})

--- a/src/test/suite-timeout.ts
+++ b/src/test/suite-timeout.ts
@@ -1,3 +1,7 @@
+/**
+ * Running this file manually should indicate that the two fast tests ran and the two slow tests didn't.
+ */
+
 import test, { setTestSuiteOptions } from '../index'
 import * as assert from 'assert'
 

--- a/src/test/suite-timeout.ts
+++ b/src/test/suite-timeout.ts
@@ -1,0 +1,23 @@
+import test, { setTestSuiteOptions } from '../index'
+import * as assert from 'assert'
+
+setTestSuiteOptions({
+    maximumDurationSeconds: 0.1,
+})
+
+const oneSecondMilliseconds = 1e3
+const delayOneSecond = () => new Promise(resolve => setTimeout(resolve, oneSecondMilliseconds))
+
+test('fast success', () => {})
+
+test('fast failure', () => assert.equal(1, 2))
+
+test('slow success', async () => {
+    await delayOneSecond()
+})
+
+test('slow failure', async () => {
+    await delayOneSecond()
+    assert.equal(1, 2)
+})
+


### PR DESCRIPTION
Closes #2. This supports a time limit, rather than the fastest fraction, but it serves the same purpose of allowing just fast tests to run.